### PR TITLE
Refactor CMake to enable/disable GPU and OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,29 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8)
 
+project(PIFUS CXX C Fortran)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (default: on)" on)
 option(BUILD_PIFUS_EXE "Build pifus driver code (default: on)" on)
 option(BUILD_GPU_CODE "Build GPU code (default: on)" on)
+
+# CUDA architecture to target
+set(PIFUS_CUDA_SM "60" CACHE STRING "CUDA arch option")
+
 if (BUILD_GPU_CODE)
- project(PIFUS CXX C Fortran CUDA)
- find_package(CUDA REQUIRED)
-else()
- project(PIFUS CXX C Fortran)
+  enable_language(CUDA)
+  add_definitions("-DGPU")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_${PIFUS_CUDA_SM}")
+  set(CMAKE_CUDA_STANDARD 11)
+  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+  set(CMAKE_CUDA_EXTENSIONS OFF)
 endif()
 
 find_package(MPI REQUIRED)
-include_directories(${MPI_INCLUDE_PATH})
+include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
+include_directories(SYSTEM ${MPI_CXX_INCLUDE_PATH})
+include_directories(SYSTEM ${MPI_Fortran_INCLUDE_PATH})
+
+find_package(OpenMP)
 
 # Ensure C++11 standard is enabled
 if (CMAKE_VERSION VERSION_LESS "3.1")
@@ -21,20 +32,18 @@ else()
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS FALSE)
-  if (BUILD_GPU_CODE) 
-    set(CMAKE_CXX_FLAGS "-DGPU -fopenmp -O3" ${CMAKE_CXX_FLAGS} )
-    set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-DGPU -arch=sm_60 -rdc=true")
-  else()
-    set(CMAKE_CXX_FLAGS "-fopenmp -O3" ${CMAKE_CXX_FLAGS})
-  endif()
 endif()
 
+if (OpenMP_FOUND)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
+  add_definitions(-DENABLE_OPENMP)
+endif()
 
 # Set some default compilation settings for Fortran compiler
 if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
-  #set(CMAKE_Fortran_FLAGS
-  #  "${CMAKE_Fortran_FLAGS} -fbounds-check -fbacktrace -fdefault-real-8 -ffree-line-length-none")
-  set(CMAKE_Fortran_FLAGS "-O3 -fdefault-real-8")
+  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -ffree-line-length-none")
 elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double_size 128")
 endif()

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -2,16 +2,24 @@
 set(PIFUS_EXE_SOURCES
   myfunc.f90)
 
-add_executable(testpifus.exe testpifus.f90 ${PIFUS_EXE_SOURCES})
-add_executable(pifus_accuracy.exe pifus_accuracy.f90 ${PIFUS_EXE_SOURCES})
-
-#target_compile_definitions(pifus.exe PUBLIC ${MPI_Fortran_COMPILE_FLAGS})
-#target_include_directories(pifus.exe PUBLIC ${MPI_Fortran_INCLUDE_PATH})
-target_link_libraries(testpifus.exe
+add_library(pifusdriver ${PIFUS_EXE_SOURCES})
+target_link_libraries(pifusdriver
   pifus ${MPI_Fortran_LIBRARIES} ${CMAKE_DL_LIBS})
 
-target_link_libraries(pifus_accuracy.exe
-  pifus ${MPI_Fortran_LIBRARIES} ${CMAKE_DL_LIBS})
+add_executable(testpifus.exe testpifus.f90)
+target_link_libraries(testpifus.exe pifusdriver)
+
+add_executable(pifus_accuracy.exe pifus_accuracy.f90)
+target_link_libraries(pifus_accuracy.exe pifusdriver)
+
+if (ENABLE_GPU_CODE)
+  set_target_properties(pifusdriver PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON)
+  set_target_properties(testpifus.exe PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON)
+  set_target_properties(pifus_accuracy.exe PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON)
+endif()
 
 set_target_properties(testpifus.exe PROPERTIES LINKER_LANGUAGE Fortran)
 set_target_properties(pifus_accuracy.exe PROPERTIES LINKER_LANGUAGE Fortran)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,8 +18,9 @@ set(PIFUS_SOURCES
   #dMeshBlock.C
   #dADT.C
   )
-if (BUILD_GPU_CODE) 
-  set (PIFUS_SOURCES ${PIFUS_SOURCES} 
+
+if (BUILD_GPU_CODE)
+  set (PIFUS_SOURCES ${PIFUS_SOURCES}
        # CUDA sources
        dMeshBlock.cu
        dADT.cu
@@ -29,6 +30,11 @@ file(GLOB PIFUS_HEADERS *.h)
 
 add_library(pifus ${PIFUS_SOURCES})
 target_link_libraries(pifus ${MPI_LIBRARIES} ${CMAKE_DL_LIBS})
+
+if (ENABLE_GPU_CODE)
+  set_target_properties(pifus PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON)
+endif()
 
 if(MPI_COMPILE_FLAGS)
   set_target_properties(pifus PROPERTIES

--- a/src/MeshBlock.C
+++ b/src/MeshBlock.C
@@ -2,7 +2,11 @@
 #include "pifus_types.h"
 #include <stdio.h>
 #include "MeshBlock.h"
+
+#ifdef ENABLE_OPENMP
 #include <omp.h>
+#endif
+
 #define BASE 0
 extern "C" {
  void interprbf_(double *,double *,double *,int *,int *,int *);


### PR DESCRIPTION
- Make OpenMP optional 
- Use CMake CUDA options to enable separable compilation
- Introduce `PIFUS_CUDA_SM` variable to provide `-arch=sm_X` capability